### PR TITLE
Added support for saving circuit state data on a reset.

### DIFF
--- a/src/main/java/org/tal/redstonechips/CircuitManager.java
+++ b/src/main/java/org/tal/redstonechips/CircuitManager.java
@@ -391,7 +391,8 @@ public class CircuitManager implements Listener {
     public boolean resetCircuit(Circuit c, CommandSender reseter) {
         Block activationBlock = c.world.getBlockAt(c.activationBlock.getBlockX(), c.activationBlock.getBlockY(), c.activationBlock.getBlockZ());
         List<CircuitListener> listeners = c.getListeners();
-
+        Map<String,Object> data = c.getResetData();
+		
         int id = c.id;
         String name = c.name;
         
@@ -403,6 +404,7 @@ public class CircuitManager implements Listener {
 
             newCircuit.id = id;
             newCircuit.name = name;
+			newCircuit.setResetData(data);
             newCircuit.getListeners().addAll(listeners);
 
             if (reseter!=null) reseter.sendMessage(rc.getPrefs().getInfoColor() + "Successfully reactivated " + ChatColor.YELLOW + newCircuit.getChipString() + rc.getPrefs().getInfoColor() + ".");

--- a/src/main/java/org/tal/redstonechips/circuit/Circuit.java
+++ b/src/main/java/org/tal/redstonechips/circuit/Circuit.java
@@ -218,9 +218,24 @@ public abstract class Circuit {
     /**
      * Called when the plugin loads a circuit from file.
      *
-     * @param state Map containing state data that was read from the file. The map should hold the same data that was returned by saveState()
+     * @param state Map containing state data that was read from the file. The map should hold the same data that was returned by getInternalState()
      */
     public void setInternalState(Map<String,String> state) {}
+
+    /**
+     * Called before the plugin resets the circuit.
+     * The circuit should return a map containing any data that may not be available on a reset condition.
+     *
+     * @return Map containing reset data.
+     */
+    public Map<String,Object> getResetData() { return new HashMap<String,Object>(); }
+
+    /**
+     * Called after the plugin resets the circuit.
+     *
+     * @param reset Map containing reset data to be restored. The map should hold the same data that was returned by setResetData()
+     */
+    public void setResetData(Map<String,Object> data) {}
 
     /**
      * Called when the circuit is physically destroyed.


### PR DESCRIPTION
This allows for circuits that get a one time input on activate and need to remember this input across resets.

This should resolve Issue #52.
