### PR TITLE
Optimizations in BitSetUtils

### DIFF
--- a/src/main/java/org/tal/redstonechips/bitset/BitSetUtils.java
+++ b/src/main/java/org/tal/redstonechips/bitset/BitSetUtils.java
@@ -96,14 +96,8 @@ public class BitSetUtils {
      * @return 
      */
     public static BitSet7 bigIntToBitSet(BigInteger i) {
-        int bitLength = i.bitLength();
-        BitSet7 bits = new BitSet7(bitLength);
-        for (int index = 0; index < bitLength; index++) {
-            bits.set(index, i.testBit(index));
-        }
-        
-        return bits;
-}
+        return BitSet7.valueOf(i.toByteArray());
+    }
    
     /**
      * Convert an integer to BitSet.


### PR DESCRIPTION
I've tried to removed all the powers by replacing them with a computationally-cheaper additions. I've also reduced a lot the overhead in bigIntToBitSet, by copying bits rather than using modulos and shifts.
